### PR TITLE
Fix mongo embeded tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine as builder
+FROM openjdk:8 as builder
 ENV a=1
 RUN mkdir /workspace
 WORKDIR /workspace
@@ -12,7 +12,7 @@ RUN ./gradlew check
 ADD src /workspace/src
 RUN ./gradlew build
 
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8
 
 COPY --from=builder /workspace/build/libs/app.jar .
 

--- a/src/test/java/io/userfeeds/airdrop/components/MongoDBTest.kt
+++ b/src/test/java/io/userfeeds/airdrop/components/MongoDBTest.kt
@@ -4,14 +4,14 @@ import io.userfeeds.airdrop.newOwner
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Assert
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
 
-@Ignore
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner::class)
 class MongoDBTest {

--- a/src/test/java/io/userfeeds/airdrop/components/MongoDBTest.kt
+++ b/src/test/java/io/userfeeds/airdrop/components/MongoDBTest.kt
@@ -7,14 +7,20 @@ import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories
+import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
 
-@SpringBootTest
+@ContextConfiguration(classes = [MongoDBTest.ApplicationConfig::class])
 @RunWith(SpringJUnit4ClassRunner::class)
 class MongoDBTest {
+
+    @Configuration
+    @EnableAutoConfiguration
+    @EnableMongoRepositories(basePackageClasses = [MongoOwnerRepository::class])
+    class ApplicationConfig
 
     @Autowired
     lateinit var mongoOwnerRepository: MongoOwnerRepository
@@ -22,8 +28,7 @@ class MongoDBTest {
     @Autowired
     lateinit var mongoTimeRepository: MongoTimeRepository
 
-    @Autowired
-    lateinit var mongo: MongoDB
+    val mongo by lazy { MongoDB(mongoOwnerRepository, mongoTimeRepository) }
 
     @Test
     fun shouldSaveOwnerToMongoDatabase() {


### PR DESCRIPTION
The reason why the tests were failing when using `openjdk:8-jdk-alpine` is because alpine image uses  musl, whereas flapdoodle (embeded Mongo) relies on glibc. 

Additional info:
https://www.reddit.com/r/linuxmasterrace/comments/41q2m9/eli5_what_is_musl_and_glibc/